### PR TITLE
Report all radio inputs whether checked or not

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ module.exports = [
   'a[href]:not([tabindex^="-"])',
   'area[href]:not([tabindex^="-"])',
   'input:not([type="hidden"]):not([type="radio"]):not([disabled]):not([tabindex^="-"])',
-  'input[type="radio"]:not([disabled]):not([tabindex^="-"]):checked',
+  'input[type="radio"]:not([disabled]):not([tabindex^="-"])',
   'select:not([disabled]):not([tabindex^="-"])',
   'textarea:not([disabled]):not([tabindex^="-"])',
   'button:not([disabled]):not([tabindex^="-"])',


### PR DESCRIPTION
The usage of `:checked` for radio inputs has been introduced in https://github.com/KittyGiraudel/focusable-selectors/commit/515e76b4da1b291f965b23f0ad691c4204c4af84. The rationale came from the following explanation in the [focus-trap/tabbable](https://github.com/focus-trap/tabbable/) library:

> &lt;input> elements
> […] will not be considered tabbable, though, if […]:
> is an &lt;input type="radio"> element and a different radio in its group is checked

I mistakenly took that as “find only checked radio inputs” which is obviously incorrect. Right now, `focusable-selectors` will not report radio inputs as focusable *unless* they are checked. Not good.

The fix introduced in this pull-request is not optimal either, because it will report *all* radio inputs as focusable, which is not technically correct. In case there is a checked radio within a group, only that one should be reported.

Unfortunately an accurate check for radio inputs is not doable via CSS selectors only, and a false positive is better than a false negative for the purpose of that library. As in: we’d rather have all radio inputs reported as focusable than none of them.