### PR TITLE
Chore: add TypeScript types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,4 @@
+declare module 'focusable-selectors' {
+  const FocusableSelectors: Array<string>
+  export default FocusableSelectors
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.3.1",
   "description": "A list of CSS selectors for focusable elements",
   "main": "index.js",
+  "types": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/KittyGiraudel/focusable-selectors.git"


### PR DESCRIPTION
## Summary
As it says on the tin. TypeScript will pitch a fit in any app that consumes `focusable-selectors` (like the future version of `a11y-dialog`), since it is currently un-typed.