### PR TITLE
Chore: add an ESM export 

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -1,0 +1,14 @@
+export default [
+  'a[href]:not([tabindex^="-"])',
+  'area[href]:not([tabindex^="-"])',
+  'input:not([type="hidden"]):not([type="radio"]):not([disabled]):not([tabindex^="-"])',
+  'input[type="radio"]:not([disabled]):not([tabindex^="-"])',
+  'select:not([disabled]):not([tabindex^="-"])',
+  'textarea:not([disabled]):not([tabindex^="-"])',
+  'button:not([disabled]):not([tabindex^="-"])',
+  'iframe:not([tabindex^="-"])',
+  'audio[controls]:not([tabindex^="-"])',
+  'video[controls]:not([tabindex^="-"])',
+  '[contenteditable]:not([tabindex^="-"])',
+  '[tabindex]:not([tabindex^="-"])',
+]

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.3.1",
   "description": "A list of CSS selectors for focusable elements",
   "main": "index.js",
-	"module": "index.mjs",
+  "module": "index.mjs",
   "types": "index.d.ts",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "url": "https://github.com/KittyGiraudel/focusable-selectors/issues"
   },
   "files": [
+    "index.d.ts",
     "index.js",
     "index.mjs"
   ]

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.3.1",
   "description": "A list of CSS selectors for focusable elements",
   "main": "index.js",
+	"module": "index.mjs",
   "types": "index.d.ts",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "url": "https://github.com/KittyGiraudel/focusable-selectors/issues"
   },
   "files": [
-    "index.js"
+    "index.js",
+    "index.mjs"
   ]
 }


### PR DESCRIPTION
## Summary
As it says on the tin. The `.mjs` extension indicates that something is an ECMAScript module and is supported in all environments that consume ESM.

⚠️ I made these changes a superset of #5, so please review and merge that first.