### PR TITLE
Add `inert` attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Focusable Selectors
 
-`focusable-selectors` is a micro-lib exporting an array of CSS selectors for focusable HTML elements. Figuring out which element can be focused is not always trivial and is sometimes necessary to build fully accessible widgets such as [a11y-dialog](https://github.com/edenspiekermann/a11y-dialog).
+`focusable-selectors` is a micro-lib exporting an array of CSS selectors for focusable HTML elements. Figuring out which element can be focused is not always trivial and is sometimes necessary to build fully accessible widgets such as [a11y-dialog](https://github.com/KittyGiraudel/a11y-dialog).
 
 It supports:
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It supports:
 - All natively focusable elements,
 - … and any element with the `contenteditable` attribute,
 - … provided they do not have the `disabled` attribute (if they even can),
-- … and do not have a negative `tabindex` attribute.
+- … and do not have a negative `tabindex` attribute or (`inert` attribute)[https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert].
 
 For a more advanced solution using JavaScript and covering more edge cases, refer to [focus-trap/tabbable](https://github.com/focus-trap/tabbable).
 
@@ -18,7 +18,7 @@ npm install --save focusable-selectors
 ```
 
 ```js
-const selectors = require('focusable-selectors')
+import focusableSelectors from 'focusable-selectors'
 ```
 
 To have a single CSS selector out of it, join the array with commas:

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
 declare module 'focusable-selectors' {
-  const FocusableSelectors: Array<string>
-  export default FocusableSelectors
+  const focusableSelectors: Array<string>
+  export default focusableSelectors
 }

--- a/index.js
+++ b/index.js
@@ -1,16 +1,17 @@
-'use strict'
+const notInertNegativeTabindex = ':not([inert]):not([tabindex^="-"])'
+const notInertNegativeTabIndexDisabled = `${notInertNegativeTabindex}:not([disabled])`
 
 module.exports = [
-  'a[href]:not([tabindex^="-"])',
-  'area[href]:not([tabindex^="-"])',
-  'input:not([type="hidden"]):not([type="radio"]):not([disabled]):not([tabindex^="-"])',
-  'input[type="radio"]:not([disabled]):not([tabindex^="-"])',
-  'select:not([disabled]):not([tabindex^="-"])',
-  'textarea:not([disabled]):not([tabindex^="-"])',
-  'button:not([disabled]):not([tabindex^="-"])',
-  'iframe:not([tabindex^="-"])',
-  'audio[controls]:not([tabindex^="-"])',
-  'video[controls]:not([tabindex^="-"])',
-  '[contenteditable]:not([tabindex^="-"])',
-  '[tabindex]:not([tabindex^="-"])',
+  `a[href]${notInertNegativeTabindex}`,
+  `area[href]${notInertNegativeTabindex}`,
+  `input:not([type="hidden"]):not([type="radio"])${notInertNegativeTabIndexDisabled}`,
+  `input[type="radio"]${notInertNegativeTabIndexDisabled}`,
+  `select${notInertNegativeTabIndexDisabled}`,
+  `textarea${notInertNegativeTabIndexDisabled}`,
+  `button${notInertNegativeTabIndexDisabled}`,
+  `iframe${notInertNegativeTabindex}`,
+  `audio[controls]${notInertNegativeTabindex}`,
+  `video[controls]${notInertNegativeTabindex}`,
+  `[contenteditable]${notInertNegativeTabindex}`,
+  `[tabindex]${notInertNegativeTabindex}`,
 ]

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const notInertNegativeTabindex = ':not([inert]):not([tabindex^="-"])'
 const notInertNegativeTabIndexDisabled = `${notInertNegativeTabindex}:not([disabled])`
 

--- a/index.mjs
+++ b/index.mjs
@@ -1,14 +1,17 @@
+const notInertNegativeTabindex = ':not([inert]):not([tabindex^="-"])'
+const notInertNegativeTabIndexDisabled = `${notInertNegativeTabindex}:not([disabled])`
+
 export default [
-  'a[href]:not([tabindex^="-"])',
-  'area[href]:not([tabindex^="-"])',
-  'input:not([type="hidden"]):not([type="radio"]):not([disabled]):not([tabindex^="-"])',
-  'input[type="radio"]:not([disabled]):not([tabindex^="-"])',
-  'select:not([disabled]):not([tabindex^="-"])',
-  'textarea:not([disabled]):not([tabindex^="-"])',
-  'button:not([disabled]):not([tabindex^="-"])',
-  'iframe:not([tabindex^="-"])',
-  'audio[controls]:not([tabindex^="-"])',
-  'video[controls]:not([tabindex^="-"])',
-  '[contenteditable]:not([tabindex^="-"])',
-  '[tabindex]:not([tabindex^="-"])',
+  `a[href]${notInertNegativeTabindex}`,
+  `area[href]${notInertNegativeTabindex}`,
+  `input:not([type="hidden"]):not([type="radio"])${notInertNegativeTabIndexDisabled}`,
+  `input[type="radio"]${notInertNegativeTabIndexDisabled}`,
+  `select${notInertNegativeTabIndexDisabled}`,
+  `textarea${notInertNegativeTabIndexDisabled}`,
+  `button${notInertNegativeTabIndexDisabled}`,
+  `iframe${notInertNegativeTabindex}`,
+  `audio[controls]${notInertNegativeTabindex}`,
+  `video[controls]${notInertNegativeTabindex}`,
+  `[contenteditable]${notInertNegativeTabindex}`,
+  `[tabindex]${notInertNegativeTabindex}`,
 ]


### PR DESCRIPTION
## Summary
When `inert` lands in Firefox 104, it'll officially be supported by all major browsers (reference: [caniuse](https://caniuse.com/mdn-api_htmlelement_inert)). It's not popular with authors yet, except for a11y nerds, but I reckon we can get ahead of the curve.

Also, we now extract repeated selectors into their own variables. This allows the array of selectors to be minified in ways that string literals can't. For example, if this goes into a minifier:

```js
`a[href]${notInertNegativeTabindex}`,
```

something like this will come out:

```js
`a[href]${e}`,
```

We'll shave bytes off of build sizes! Bytes!