### PR TITLE
Add support for <summary> elements

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,8 @@ module.exports = [
   `select${not.inert}${not.negTabIndex}${not.disabled}`,
   `textarea${not.inert}${not.negTabIndex}${not.disabled}`,
   `button${not.inert}${not.negTabIndex}${not.disabled}`,
+  `details > summary:first-of-type${not.inert}${not.negTabIndex}`,
+  `details:not(:has(> summary))${not.inert}${not.negTabIndex}`,
   `iframe${not.inert}${not.negTabIndex}`,
   `audio[controls]${not.inert}${not.negTabIndex}`,
   `video[controls]${not.inert}${not.negTabIndex}`,

--- a/index.mjs
+++ b/index.mjs
@@ -12,6 +12,8 @@ export default [
   `select${not.inert}${not.negTabIndex}${not.disabled}`,
   `textarea${not.inert}${not.negTabIndex}${not.disabled}`,
   `button${not.inert}${not.negTabIndex}${not.disabled}`,
+  `details > summary:first-of-type${not.inert}${not.negTabIndex}`,
+  `details:not(:has(> summary))${not.inert}${not.negTabIndex}`,
   `iframe${not.inert}${not.negTabIndex}`,
   `audio[controls]${not.inert}${not.negTabIndex}`,
   `video[controls]${not.inert}${not.negTabIndex}`,

--- a/test.js
+++ b/test.js
@@ -125,6 +125,44 @@ describe('<button> elements', () => {
   })
 })
 
+describe('<details> elements', () => {
+  const selector = focusableSelectors.find(
+    selector =>
+      selector.startsWith('details') &&
+      !selector.startsWith('details > summary')
+  )
+
+  it('should only include elements without a summary', () => {
+    assert.match(selector, re(':not(:has(> summary))'))
+  })
+
+  it('should only include elements without [inert]', () => {
+    assert.match(selector, re(':not([inert])'))
+  })
+
+  it('should only include elements without negative [tabindex]', () => {
+    assert.match(selector, re(':not([tabindex^="-"])'))
+  })
+})
+
+describe('<summary> elements', () => {
+  const selector = focusableSelectors.find(selector =>
+    selector.startsWith('details > summary')
+  )
+
+  it('should only include elements that are first of type', () => {
+    assert.match(selector, re('summary:first-of-type'))
+  })
+
+  it('should only include elements without [inert]', () => {
+    assert.match(selector, re(':not([inert])'))
+  })
+
+  it('should only include elements without negative [tabindex]', () => {
+    assert.match(selector, re(':not([tabindex^="-"])'))
+  })
+})
+
 describe('<iframe> elements', () => {
   const selector = focusableSelectors.find(selector =>
     selector.startsWith('iframe')


### PR DESCRIPTION
This pull-request adds two additional selectors to consider `<summary>` elements.

1. This considers the first `summary` element directly within a `details` element focusable, provided it doesn’t have a negative `tabindex` attribute.
```css
details > summary:first-of-type:not([tabindex^="-"])
```
2. This consider the `details` element focusable provided it does not have a `summary` element and does not have a negative `tabindex` attribute.
```css
details:not(:has(> summary)):not([tabindex^="-"])
```

Find more information about this in the [HTML specifications](https://html.spec.whatwg.org/multipage/interactive-elements.html#the-summary-element).