### PR TITLE
Add an export map to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,17 @@
 {
   "name": "focusable-selectors",
+  "type": "module",
   "version": "0.7.0",
   "description": "A list of CSS selectors for focusable elements",
-  "main": "index.js",
-  "module": "index.mjs",
-  "types": "index.d.ts",
+  "main": "./index.js",
+  "module": "./index.mjs",
+  "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./index.mjs",
+      "require": "./index.js"
+    }
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/KittyGiraudel/focusable-selectors.git"
@@ -24,9 +31,9 @@
     "url": "https://github.com/KittyGiraudel/focusable-selectors/issues"
   },
   "files": [
-    "index.d.ts",
-    "index.js",
-    "index.mjs"
+    "./index.d.ts",
+    "./index.js",
+    "./index.mjs"
   ],
   "scripts": {
     "test": "node test.js"

--- a/test.js
+++ b/test.js
@@ -1,6 +1,6 @@
-const { describe, it } = require('node:test')
-const { strict: assert } = require('node:assert')
-const focusableSelectors = require('./')
+import { describe, it } from 'node:test'
+import { strict as assert } from 'node:assert'
+import focusableSelectors from './index.mjs'
 
 const escapeRegExp = string => string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 const re = string => new RegExp(escapeRegExp(string))


### PR DESCRIPTION
## Summary
This PR adds an export map with conditional exports to the package file. Export maps allow a package to assert which file should be imported depending on the import type.

## Why
I _think_ I discovered a bug while using `focusable-selectors` in a project of my own, but it's difficult to prove a fix locally.

I removed `@rollup/plugin-commonjs` because my only import is `focusable-selectors`, and I did not expect to need to transform CJS modules because `focusable-selectors` is supposed to export an ESM module. Without the CommonJS plugin, however, my build fails.

Like I said, it's hard to test a fix without installing a new version of `focusable-selectors` (locally linked modules behave kind of strangely). Even if this change doesn't fix my bug, nor will it hurt this module or any of its users.

## References
- [Conditional exports (NodeJS docs)](https://nodejs.org/api/packages.html#conditional-exports)
