### PR TITLE
fix: expose types in external exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "exports": {
     ".": {
       "import": "./index.mjs",
-      "require": "./index.js"
+      "require": "./index.js",
+      "types": "./index.d.ts"
     }
   },
   "repository": {


### PR DESCRIPTION
makes my lsp happy about type definitions